### PR TITLE
Fixed off-by-one error and removed redundant code

### DIFF
--- a/mpeds/mpeds/solr.py
+++ b/mpeds/mpeds/solr.py
@@ -74,23 +74,12 @@ class Solr:
         ## add 100 to get everything for sure
         numFound += interval
 
-        prev = 0
-        data = {
-            'q': q,
-            'rows': interval,
-            'start': prev,
-            'wt': 'json'
-        }
-
-        if fq:
-            data['fq'] = fq
-
         articles = []
         for i in range(0, numFound, interval):
             data = {
                 'q': q,
                 'rows': interval,
-                'start': prev,
+                'start': i,
                 'wt': 'json'
             }
 
@@ -107,6 +96,5 @@ class Solr:
             if i % 1000 == 0:
                 print('%d documents collected.' % i)
 
-            prev = i
-
         return articles
+


### PR DESCRIPTION
I noticed this after transferring this file over to MAI, but I figured it was worth PRing here since it might have affected MPEDS's SOLR pulls in the past?  However that means I've tested it from my MAI data sandbox but not within MPEDS, so you should probably test the fix with MPEDS to make sure nothing in there is depending on the old version...

Anyway, the problem is that `getDocuments` was pulling the first interval's worth of articles twice.  The fix leaves an extra SOLR call in at the end, which I _think_ will always be redundant (as I understand it, if my fix creates another off-by-one error on the other side then SOLR just won't return anything for the final call).  But the old code would return duplicate articles (which hopefully MPEDS deduped elsewhere?); and that should be fixed now.  I also took out a block of code that wasn't doing anything (it set a variable that was reset immediately afterward).